### PR TITLE
fix: use byte-size instead of filesize

### DIFF
--- a/lib/format-result.js
+++ b/lib/format-result.js
@@ -1,6 +1,6 @@
 const SimpleTable = require('cli-simple-table');
 const chalk = require('chalk');
-const filesize = require('filesize');
+const byteSize = require('byte-size');
 const { version } = require('../package');
 
 const normalizeThresholds = (thresholds) => (thresholds || [])
@@ -27,7 +27,7 @@ const normalizeThresholds = (thresholds) => (thresholds || [])
 const calcGrowth = (before, after) => {
 	const diff = after[0] - before[0];
 	if (diff === 0) { return ''; }
-	return chalk[diff <= 0 ? 'green' : 'redBright'](`${diff >= 0 ? '+' : ''}${filesize(diff)}`);
+	return chalk[diff <= 0 ? 'green' : 'redBright'](`${diff >= 0 ? '+' : ''}${byteSize(diff)}`);
 };
 
 const compareOld = (before, after) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const filesize = require('filesize');
+const byteSize = require('byte-size');
 const gzipSize = require('gzip-size');
 const path = require('path');
 const { promisify } = require('util');
@@ -85,8 +85,8 @@ class DistsizePlugin {
 				return {
 					name: a.name,
 					size: {
-						raw: [a.size, filesize(a.size)],
-						gzip: [gzip, filesize(gzip)],
+						raw: [a.size, byteSize(a.size).toString()],
+						gzip: [gzip, byteSize(gzip).toString()],
 					},
 				};
 			});
@@ -99,8 +99,8 @@ class DistsizePlugin {
 		const result = {
 			hash: stats.hash,
 			totalSize: {
-				raw: [totalSize, filesize(totalSize)],
-				gzip: [totalGzipSize, filesize(totalGzipSize)],
+				raw: [totalSize, byteSize(totalSize).toString()],
+				gzip: [totalGzipSize, byteSize(totalGzipSize).toString()],
 			},
 			assets,
 		};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1569,6 +1569,11 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
+    "byte-size": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-7.0.0.tgz",
+      "integrity": "sha512-NNiBxKgxybMBtWdmvx7ZITJi4ZG+CYUgwOSZTfqB1qogkRHrhbQE/R2r5Fh94X+InN5MCYz6SvB/ejHMj/HbsQ=="
+    },
     "cacache": {
       "version": "12.0.4",
       "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/cacache/-/cacache-12.0.4.tgz",
@@ -3178,11 +3183,6 @@
       "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
       "dev": true,
       "optional": true
-    },
-    "filesize": {
-      "version": "6.1.0",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/filesize/-/filesize-6.1.0.tgz",
-      "integrity": "sha1-6Bvap4DiRR1xTXHA16TzI403rQA="
     },
     "fill-range": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     "webpack-merge": "^4.2.2"
   },
   "dependencies": {
+    "byte-size": "^7.0.0",
     "chalk": "^4.0.0",
     "cli-simple-table": "0.0.1",
-    "filesize": "^6.1.0",
     "gzip-size": "^5.1.1",
     "lodash": "^4.17.15",
     "minimist": "^1.2.5"


### PR DESCRIPTION
[byte-size](https://www.npmjs.com/package/byte-size) is used by npm and seems to be formatting bytes differently than [filesize](https://www.npmjs.com/package/filesize).

byte-size defaults to metric and filesize defaults to jedec.